### PR TITLE
[vim] caw.vimのdeprecatedなコマンド名を置き換え

### DIFF
--- a/dot.vimrc
+++ b/dot.vimrc
@@ -134,8 +134,8 @@ autocmd VimEnter,Colorscheme * :hi IndentGuidesEven ctermbg=236
 let g:indent_guides_guide_size=1
 
 " caw.vim
-nmap <Leader>c <Plug>(caw:i:toggle)
-vmap <Leader>c <Plug>(caw:i:toggle)
+nmap <Leader>c <Plug>(caw:hatpos:toggle)
+vmap <Leader>c <Plug>(caw:hatpos:toggle)
 
 " ファイル保存時に行末の空白を削除する
 function! s:remove_dust()


### PR DESCRIPTION
[My Future Sight for Past: caw.vim was changed command name "i, I, a" -> "hatpos, zeropos, dollarpos" on 2016-03-20 and 2016-03-28](http://myfuturesightforpast.blogspot.com/2016/03/cawvim-was-changed-command-name-i-i.html)