### PR TITLE
[tmux] prefixはdefaultのものを使う

### DIFF
--- a/dot.tmux.conf
+++ b/dot.tmux.conf
@@ -1,6 +1,3 @@
-# prefix key
-set -g prefix C-t
-
 # vi like key binding
 set-window-option -g mode-keys vi
 


### PR DESCRIPTION
defaultに慣れた方がたぶんポータビリティが良い。